### PR TITLE
Update PyDelphin interface and other small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ A library for manipulating DMRS structures.
 
 ### References
 
-- [Copestake (2007)](http://www.aclweb.org/anthology/E/E09/E09-1001.pdf)
+- [Copestake (2009)](http://www.aclweb.org/anthology/E/E09/E09-1001.pdf)
 - [Copestake et al. (2016)](http://www.lrec-conf.org/proceedings/lrec2016/pdf/634_Paper.pdf)

--- a/pydmrs/pydelphin_interface.py
+++ b/pydmrs/pydelphin_interface.py
@@ -12,9 +12,8 @@ DEFAULT_ERG_FILE = get_config_option(config, 'Grammar', 'ERG')
 
 def parse(sentence, cls=ListDmrs, erg_file=DEFAULT_ERG_FILE):
     results = []
-    for result in ace.parse(erg_file, sentence)['RESULTS']:  # cmdargs=['-r', 'root_informal']
-        mrs = result['MRS']
-        xmrs = simplemrs.loads_one(mrs)
+    for result in ace.parse(erg_file, sentence).results():  # cmdargs=['-r', 'root_informal']
+        xmrs = result.mrs()
         dmrs_xml = dmrx.dumps_one(xmrs)[11:-12]
         dmrs = cls.loads_xml(dmrs_xml)
         results.append(dmrs)
@@ -26,7 +25,7 @@ def generate(dmrs, erg_file=DEFAULT_ERG_FILE):
     xmrs = dmrx.loads_one(dmrs_xml)
     mrs = simplemrs.dumps_one(xmrs)
     results = []
-    for result in ace.generate(erg_file, mrs)['RESULTS']:
-        sentence = result['SENT']
+    for result in ace.generate(erg_file, mrs).results():
+        sentence = result['surface']
         results.append(sentence)
     return results

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
   name = 'pydmrs',
   version = VERSION,
   description = 'A library for manipulating DMRS graphs',
-  author = 'Ann Copestake, Guy Emerson, Mike Goodman, Matic Horvat, Alex Kuhnle, Ewa Muszyńska',
+  author = 'Ann Copestake, Guy Emerson, Michael Wayne Goodman, Matic Horvat, Alex Kuhnle, Ewa Muszyńska',
   author_email = 'gete2@cam.ac.uk',
   license = 'MIT',
   url = 'https://github.com/delph-in/pydmrs',


### PR DESCRIPTION
I'm removing the ACE interface duct-tape in PyDelphin, so I fixed your code to match the new state. Both the old and new interface were available for almost two years, so this shouldn't break compatibility with any moderately current version of PyDelphin.

I also added a couple other unrelated fixes to this PR:
  - Fixing #20 (Copestake 2009 citation year)
  - Changing my name in the "author" field of setup.py (although my contribution is minimal; I suppose it could be removed altogether?)

The two extra changes are added as separate commits, which should make it easy to ignore if you don't want to include them.