### PR TITLE
Update pydmrs.pydelphin_interface to v1.0.1

### DIFF
--- a/pydmrs/pydelphin_interface.py
+++ b/pydmrs/pydelphin_interface.py
@@ -1,5 +1,8 @@
-from delphin.interfaces import ace
-from delphin.mrs import simplemrs, dmrx
+
+from delphin import ace
+from delphin.mrs import from_dmrs
+from delphin.dmrs import from_mrs
+from delphin.codecs import simplemrs, dmrx
 
 from pydmrs.core import ListDmrs
 from pydmrs.utils import load_config, get_config_option
@@ -13,17 +16,19 @@ DEFAULT_ERG_FILE = get_config_option(config, 'Grammar', 'ERG')
 def parse(sentence, cls=ListDmrs, erg_file=DEFAULT_ERG_FILE):
     results = []
     for result in ace.parse(erg_file, sentence).results():  # cmdargs=['-r', 'root_informal']
-        xmrs = result.mrs()
-        dmrs_xml = dmrx.dumps_one(xmrs)[11:-12]
+        mrs = result.mrs()
+        _dmrs = from_mrs(mrs)
+        dmrs_xml = dmrx.encode(_dmrs)
         dmrs = cls.loads_xml(dmrs_xml)
         results.append(dmrs)
     return results
 
 
 def generate(dmrs, erg_file=DEFAULT_ERG_FILE):
-    dmrs_xml = '<dmrs-list>' + dmrs.dumps_xml(encoding='utf-8') + '</dmrs-list>'
-    xmrs = dmrx.loads_one(dmrs_xml)
-    mrs = simplemrs.dumps_one(xmrs)
+    dmrs_xml = dmrs.dumps_xml(encoding='utf-8')
+    _dmrs = dmrx.decode(dmrs_xml)
+    _mrs = from_dmrs(_dmrs)
+    mrs = simplemrs.encode(_mrs)
     results = []
     for result in ace.generate(erg_file, mrs).results():
         sentence = result['surface']

--- a/pydmrs/serial.py
+++ b/pydmrs/serial.py
@@ -21,8 +21,9 @@ def loads_xml(bytestring, encoding=None, cls=ListDmrs, convert_legacy_prontype=T
     dmrs.cto = int(xml.get('cto')) if 'cto' in xml.attrib else None
     dmrs.surface = xml.get('surface')
     dmrs.ident = int(xml.get('ident')) if 'ident' in xml.attrib else None
+    # top may be set as a graph attribute or as a link (see below)
+    top_id = int(xml.get('top')) if 'top' in xml.attrib else None
     index_id = int(xml.get('index')) if 'index' in xml.attrib else None
-    top_id = None
 
     for elem in xml:
         if elem.tag == 'node':
@@ -32,6 +33,9 @@ def loads_xml(bytestring, encoding=None, cls=ListDmrs, convert_legacy_prontype=T
         elif elem.tag == 'link':
             link = Link.from_xml(elem)
             if link.start == 0:
+                # this would overwrite any graph-level top attribute
+                # (see above), but let's assume we won't encounter
+                # both in the same graph
                 top_id = link.end
             else:
                 dmrs.add_link(link)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
   packages = find_packages(),
   package_data = {'pydmrs': ['__config__/*.conf']},
   install_requires = [
-    'pydelphin'
+    'pydelphin >= 1.0.1'
   ]
 )


### PR DESCRIPTION
Updating this to v1.0.0 revealed several bugs for DMRS-to-MRS
conversion which pydmrs uses for the generate() function, so I created
the v1.0.1 patch release and made pydmrs depend on it.